### PR TITLE
Add Nix Packages and NixOS Options search sources

### DIFF
--- a/SearchEngines.qml
+++ b/SearchEngines.qml
@@ -143,6 +143,20 @@ QtObject {
             keywords: ["aur", "arch", "packages"]
         },
         {
+            id: "nixpkgs",
+            name: "Nix Packages",
+            icon: "material:ac_unit",
+            url: "https://search.nixos.org/packages?channel=unstable&query=%s",
+            keywords: ["nixpkgs", "pkgs"]
+        },
+        {
+            id: "nixopts",
+            name: "NixOS Options",
+            icon: "material:ac_unit",
+            url: "https://search.nixos.org/options?channel=unstable&query=%s",
+            keywords: ["nixopts", "opts"]
+        },
+        {
             id: "npmjs",
             name: "npm",
             icon: "unicode:",


### PR DESCRIPTION
Used AC Unit "snowflake" icon, as a reference to Nix flakes. Used the "unstable" branch as a search source to avoid needing to bump the version manually for the URL argument. If they ever implement a "stable" argument, we can use that too.